### PR TITLE
Ensure all groups for user are created

### DIFF
--- a/roles/comb/tasks/user.yml
+++ b/roles/comb/tasks/user.yml
@@ -21,6 +21,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---
+- shell: echo {{ user.groups }} | tr ',' '\n'
+  register: grouplist
+- group: name={{ item }}
+  with_items: "{{ grouplist.stdout_lines }}"
 - name: Install privileged user
   user: name={{ user.handle }} shell={{ user.shell }} groups={{ user.groups }} append=yes
 - name: Deploy authorized key


### PR DESCRIPTION
If group_vars:user.groups contains groups that do not exist, the user
module will fail to create the user.

user.groups is a comma-separated list of groups, so split the list and
ensure the group is present.